### PR TITLE
Update get-config.ts

### DIFF
--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -11,7 +11,7 @@ type MongoDBEngineConfig = {
   migrationRecordCollection: string;
 };
 
-const validProtocol = ['mongodb', 'mongodb+srv'];
+const validProtocol = ['mongodb', 'mongodb srv'];
 
 export function getConfig(
   uri: string
@@ -21,7 +21,7 @@ export function getConfig(
 } {
   try {
     const {
-      protocol: parsedProtocol,
+      protocol,
       hostname: host,
       path,
       params
@@ -32,12 +32,9 @@ export function getConfig(
       }
     });
 
-    if (!parsedProtocol) {
+    if (!protocol) {
       throw new Error(`[URI] missing: protocol!`);
     }
-
-    // `ConnectionString` replaces `+` in protocol with ` `
-    const protocol = parsedProtocol.replace(' ', '+');
 
     if (!validProtocol.includes(protocol)) {
       throw new Error(`[URI] unsupported: protocol(${protocol})!`);


### PR DESCRIPTION
`ConnectionString` correctly replaces each `+` with space, because this is what the standard URL syntax is.

MongoDB decided to deviate from that, by treating `+` as just `+`. It is a bit a weird syntax, because they should have used `:` instead, i.e. like `mongodb:srv`, which is the proper way of doing it for the protocol.

This PR suggests that instead of patching the result from `ConnectionString`, to correct your expectation within `validProtocol` value, then you can just use it as is.

Note that the change will also make it work when the protocol is like `mongodb%20srv`, because `%20` is also a white-space in the URL ;)